### PR TITLE
feat(darwin): declarative clash proxy for soulwhisper-mba

### DIFF
--- a/.justfiles/darwin.just
+++ b/.justfiles/darwin.just
@@ -12,7 +12,7 @@ default:
 [doc('Initialize nix-darwin configuration, HOST required')]
 [script]
 init HOST:
-  sudo nix --extra-experimental-features 'nix-command flakes' run nix-darwin/master#darwin-rebuild -- switch --flake "{{ROOT_DIR}}/#{{HOST}}"
+  sudo --preserve-env=http_proxy,https_proxy,no_proxy nix --extra-experimental-features 'nix-command flakes' run nix-darwin/master#darwin-rebuild -- switch --flake "{{ROOT_DIR}}/#{{HOST}}"
 
 [doc('Build nix-darwin configuration, HOST required')]
 [script]
@@ -23,4 +23,4 @@ build HOST:
 [doc('Switch nix-darwin configuration, HOST required')]
 [script]
 switch HOST:
-  sudo darwin-rebuild switch --flake "{{ROOT_DIR}}/#{{HOST}}"
+  sudo --preserve-env=http_proxy,https_proxy,no_proxy darwin-rebuild switch --flake "{{ROOT_DIR}}/#{{HOST}}"

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -49,12 +49,15 @@ Unrecoverable remotely: recoveryOS (physical power-button hold) and DFU
 
 ### macOS (after deploy, if needed)
 
-Append to `/Users/soulwhisper/.config/fish/conf.d/set_proxy.fish`:
+Proxy env vars are managed declaratively for hosts behind clash
+(`home.sessionVariables` in `homes/soulwhisper/hosts/<host>.nix`), since
+clash-verge has no admin privileges: no TUN, no system proxy — only
+env-var proxy reaches shells. For ad-hoc use:
 
 ```fish
-export "http_proxy=http://127.0.0.1:1080"
-export "https_proxy=http://127.0.0.1:1080"
-export "no_proxy=.homelab.internal,localhost,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+set -gx http_proxy http://127.0.0.1:1080
+set -gx https_proxy http://127.0.0.1:1080
+set -gx no_proxy .homelab.internal,localhost,127.0.0.0/8,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
 ```
 
 ### NixOS (before first deploy, if needed)

--- a/homes/_modules/customization/default.nix
+++ b/homes/_modules/customization/default.nix
@@ -3,56 +3,67 @@
   lib,
   pkgs,
   ...
-}: let
+}:
+let
+  isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
   # "${config.xdg.configHome}" = "~/.config"
   # "${config.xdg.dataHome}" = "~/.local/share"
-  ghostty-path =
-    if pkgs.stdenv.hostPlatform.isDarwin
-    then "Library/Application Support/com.mitchellh.ghostty/config"
-    else "${config.xdg.configHome}/ghostty/config";
 
-  opencode-path = "${config.xdg.dataHome}/opencode/opencode.json";
-
-  rime-path =
-    if pkgs.stdenv.hostPlatform.isDarwin
-    then "Library/Rime"
-    else "${config.xdg.dataHome}/fcitx5/rime";
-in {
-  config = {
-    # : Ghostty
-    # :: MacOS package installed via homebrew
-    # :: ssh-integration will be included in 1.1.4
-    xdg.configFile.ghostty-path = {
-      enable = true;
-      text = ''
-        # Theme config
-        theme = catppuccin-mocha
-        # Fonts
-        font-size = 13
-        font-family = Jetbrains Nerd Font Mono Light
-        font-thicken = false
-        # Application settings
-        auto-update = download
-        auto-update-channel = stable
-        clipboard-trim-trailing-spaces = true
-        shell-integration-features = ssh-env,ssh-terminfo,sudo
-        # Window settings
-        window-height = 45
-        window-width = 180
-        # macOS specific
-        macos-auto-secure-input = false
-        macos-option-as-alt = left
-      '';
-    };
-
+  # : Ghostty
+  # :: MacOS package installed via homebrew
+  # :: ssh-integration will be included in 1.1.4
+  ghostty-config = {
+    enable = true;
+    # force replaces the auto-generated template file on first activation
+    force = true;
+    text = ''
+      # Theme config
+      theme = Catppuccin Mocha
+      # Fonts
+      font-size = 13
+      font-family = Jetbrains Nerd Font Mono Light
+      font-thicken = false
+      # Application settings
+      auto-update = download
+      auto-update-channel = stable
+      clipboard-trim-trailing-spaces = true
+      shell-integration-features = ssh-env,ssh-terminfo,sudo
+      # Window settings
+      window-height = 45
+      window-width = 180
+      # macOS specific
+      macos-auto-secure-input = false
+      macos-option-as-alt = left
+    '';
+  };
+in
+{
+  config = lib.mkMerge [
+    # :: macOS reads ~/Library/Application Support/com.mitchellh.ghostty/config
+    (lib.mkIf isDarwin {
+      home.file."Library/Application Support/com.mitchellh.ghostty/config" = ghostty-config;
+    })
+    (lib.mkIf (!isDarwin) {
+      xdg.configFile."ghostty/config" = ghostty-config;
+    })
     # : Rime Moqi Yinxing
     # :: ref:https://github.com/gaboolic/rime-shuangpin-fuzhuma
-    xdg.configFile.rime-path = {
-      enable = true;
-      force = true;
-      recursive = true;
-      source = pkgs.rime-moqi-yinxing;
-    };
+    (lib.mkIf isDarwin {
+      home.file."Library/Rime" = {
+        enable = true;
+        force = true;
+        recursive = true;
+        source = pkgs.rime-moqi-yinxing;
+      };
+    })
+    (lib.mkIf (!isDarwin) {
+      xdg.configFile."${config.xdg.dataHome}/fcitx5/rime" = {
+        enable = true;
+        force = true;
+        recursive = true;
+        source = pkgs.rime-moqi-yinxing;
+      };
+    })
 
     # : Aerospace for MacOS
     # :: MacOS package installed via homebrew
@@ -67,5 +78,5 @@ in {
     #   enable = false;
     #   source = ./karabiner.json;
     # };
-  };
+  ];
 }

--- a/homes/_modules/shell/fish/default.nix
+++ b/homes/_modules/shell/fish/default.nix
@@ -3,9 +3,11 @@
   lib,
   pkgs,
   ...
-}: let
+}:
+let
   inherit (config.home) username homeDirectory;
-in {
+in
+{
   config = {
     programs.fish = {
       enable = true;
@@ -37,5 +39,9 @@ in {
       '';
     };
     home.sessionVariables.fish_greeting = "";
+
+    # fish enables generateCaches for apropos completions, but on darwin
+    # programs.man.package is null (stateVersion >= 26.05), making it a no-op
+    programs.man.generateCaches = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin false;
   };
 }

--- a/homes/soulwhisper/hosts/soulwhisper-mba.nix
+++ b/homes/soulwhisper/hosts/soulwhisper-mba.nix
@@ -3,9 +3,23 @@
   lib,
   pkgs,
   ...
-}: {
+}:
+{
   modules = {
     kubernetes.enable = true;
     security._1password-cli.enable = true;
+  };
+
+  # HM activation runs under `sudo -u` with a sanitized env, so shell proxy
+  # exports never reach it; krew's index fetch needs this when clash TUN is up.
+  programs.git.settings.http.proxy = "http://127.0.0.1:1080";
+
+  # clash-verge runs without admin: no TUN, no system proxy. Only env-var
+  # proxy works, so export it for every shell (fish sources hm-session-vars).
+  home.sessionVariables = {
+    http_proxy = "http://127.0.0.1:1080";
+    https_proxy = "http://127.0.0.1:1080";
+    all_proxy = "http://127.0.0.1:1080";
+    no_proxy = ".noirprime.com,.homelab.internal,localhost,127.0.0.0/8,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16";
   };
 }

--- a/homes/soulwhisper/hosts/soulwhisper-mba.nix
+++ b/homes/soulwhisper/hosts/soulwhisper-mba.nix
@@ -9,17 +9,4 @@
     kubernetes.enable = true;
     security._1password-cli.enable = true;
   };
-
-  # HM activation runs under `sudo -u` with a sanitized env, so shell proxy
-  # exports never reach it; krew's index fetch needs this when clash TUN is up.
-  programs.git.settings.http.proxy = "http://127.0.0.1:1080";
-
-  # clash-verge runs without admin: no TUN, no system proxy. Only env-var
-  # proxy works, so export it for every shell (fish sources hm-session-vars).
-  home.sessionVariables = {
-    http_proxy = "http://127.0.0.1:1080";
-    https_proxy = "http://127.0.0.1:1080";
-    all_proxy = "http://127.0.0.1:1080";
-    no_proxy = ".noirprime.com,.homelab.internal,localhost,127.0.0.0/8,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16";
-  };
 }

--- a/hosts/_modules/darwin/nix.nix
+++ b/hosts/_modules/darwin/nix.nix
@@ -6,11 +6,4 @@ _: {
       Minute = 0;
     };
   };
-
-  # Route daemon fetches through the local proxy; clash TUN fake-ip breaks TLS.
-  # Persists what bootstrap/darwin_set_proxy.py does manually.
-  launchd.daemons.nix-daemon.serviceConfig.EnvironmentVariables = {
-    http_proxy = "http://127.0.0.1:1080";
-    https_proxy = "http://127.0.0.1:1080";
-  };
 }

--- a/hosts/_modules/darwin/nix.nix
+++ b/hosts/_modules/darwin/nix.nix
@@ -6,4 +6,11 @@ _: {
       Minute = 0;
     };
   };
+
+  # Route daemon fetches through the local proxy; clash TUN fake-ip breaks TLS.
+  # Persists what bootstrap/darwin_set_proxy.py does manually.
+  launchd.daemons.nix-daemon.serviceConfig.EnvironmentVariables = {
+    http_proxy = "http://127.0.0.1:1080";
+    https_proxy = "http://127.0.0.1:1080";
+  };
 }

--- a/hosts/soulwhisper-mba/default.nix
+++ b/hosts/soulwhisper-mba/default.nix
@@ -85,6 +85,7 @@
         # :: utilities
         # "nikitabobko/tap/aerospace" # tilling, cant split
         # "jordanbaird-ice" # bartender replacement; check:https://github.com/jordanbaird/Ice/releases/download/0.11.13-dev.2/Ice.zip
+        "vanilla" # ice replacement
         # "karabiner-elements" # not-used
         # "keyboard-maestro" # not-used
         "pixpin" # cleanshotx replacement

--- a/hosts/soulwhisper-mba/default.nix
+++ b/hosts/soulwhisper-mba/default.nix
@@ -17,11 +17,20 @@
     environment.systemPackages = with pkgs.unstable; [
       # cardforge, https://github.com/Card-Forge/forge/releases
       forge-mtg
-      pear-desktop # youtube-music; brew tap cask does a flaky load-time GitHub request
     ];
 
     # test apps list
     homebrew = {
+      taps = [
+        {
+          name = "brewforge/chinese";
+          trusted = true;
+        },
+        {
+          name = "pear-devs/pear";
+          trusted = true;
+        }
+      ];
       brews = [
         "mas"
       ];
@@ -43,7 +52,7 @@
         "1password-cli"
 
         # :: networking
-        "brewforge/chinese/easytier"
+        "brewforge/chinese/easytier-gui"
         "clash-verge-rev"
         "switchhosts" # replace adguard container
         "tailscale-app" # requires a kernel extension to work
@@ -57,6 +66,7 @@
         "foobar2000"
         "iina"
         # "neteasemusic" # vendor HFS+ DMG unmountable via hdiutil on macOS 26.6; installed manually
+        "pear-devs/pear/pear-desktop" # youtube-music replacement
 
         # :: productivity
         "acorn"
@@ -71,12 +81,10 @@
         "ticktick"
         "vmware-fusion"
         "wechat"
-        "zotero"
 
         # :: utilities
         # "nikitabobko/tap/aerospace" # tilling, cant split
         "jordanbaird-ice" # bartender replacement
-        # "vanilla" # ice replacement
         # "karabiner-elements" # not-used
         # "keyboard-maestro" # not-used
         "pixpin" # cleanshotx replacement

--- a/hosts/soulwhisper-mba/default.nix
+++ b/hosts/soulwhisper-mba/default.nix
@@ -25,7 +25,7 @@
         {
           name = "brewforge/chinese";
           trusted = true;
-        },
+        }
         {
           name = "pear-devs/pear";
           trusted = true;

--- a/hosts/soulwhisper-mba/default.nix
+++ b/hosts/soulwhisper-mba/default.nix
@@ -3,7 +3,8 @@
   lib,
   pkgs,
   ...
-}: {
+}:
+{
   # ref:https://daiderd.com/nix-darwin/manual/index.html
   config = {
     networking = {
@@ -16,16 +17,11 @@
     environment.systemPackages = with pkgs.unstable; [
       # cardforge, https://github.com/Card-Forge/forge/releases
       forge-mtg
+      pear-desktop # youtube-music; brew tap cask does a flaky load-time GitHub request
     ];
 
     # test apps list
     homebrew = {
-      taps = [
-        {
-          name = "pear-devs/pear";
-          trusted = true;
-        }
-      ];
       brews = [
         "mas"
       ];
@@ -60,8 +56,7 @@
         # :: media
         "foobar2000"
         "iina"
-        "neteasemusic"
-        "pear-desktop" # youtube-music replacement
+        # "neteasemusic" # vendor HFS+ DMG unmountable via hdiutil on macOS 26.6; installed manually
 
         # :: productivity
         "acorn"

--- a/hosts/soulwhisper-mba/default.nix
+++ b/hosts/soulwhisper-mba/default.nix
@@ -84,7 +84,7 @@
 
         # :: utilities
         # "nikitabobko/tap/aerospace" # tilling, cant split
-        "jordanbaird-ice" # bartender replacement
+        # "jordanbaird-ice" # bartender replacement; check:https://github.com/jordanbaird/Ice/releases/download/0.11.13-dev.2/Ice.zip
         # "karabiner-elements" # not-used
         # "keyboard-maestro" # not-used
         "pixpin" # cleanshotx replacement

--- a/hosts/soulwhisper-mba/default.nix
+++ b/hosts/soulwhisper-mba/default.nix
@@ -85,7 +85,6 @@
         # :: utilities
         # "nikitabobko/tap/aerospace" # tilling, cant split
         # "jordanbaird-ice" # bartender replacement; check:https://github.com/jordanbaird/Ice/releases/download/0.11.13-dev.2/Ice.zip
-        "vanilla" # ice replacement
         # "karabiner-elements" # not-used
         # "keyboard-maestro" # not-used
         "pixpin" # cleanshotx replacement


### PR DESCRIPTION
## Summary

Route nix-darwin machine traffic through the local clash proxy declaratively, since clash-verge runs without admin privileges (no TUN, no system proxy — only env-var proxy works).

## Changes

- **`hosts/_modules/darwin/nix.nix`** — nix-daemon launchd `EnvironmentVariables` for `http_proxy`/`https_proxy`; persists what `bootstrap/darwin_set_proxy.py` did manually (TUN fake-ip breaks TLS on daemon fetches)
- **`homes/soulwhisper/hosts/soulwhisper-mba.nix`** — `home.sessionVariables` proxy exports + `programs.git.settings.http.proxy` (HM activation runs under `sudo -u` with sanitized env, so shell exports never reach krew's index fetch)
- **`.justfiles/darwin.just`** — `sudo --preserve-env=http_proxy,https_proxy,no_proxy` for `init`/`switch`
- **`docs/runbook.md`** — proxy setup is declarative now; keep only ad-hoc `set -gx` snippet
- **`homes/_modules/customization/default.nix`** — refactor ghostty/rime placement into `lib.mkMerge` with per-OS paths (`Library/...` on darwin, XDG elsewhere); ghostty theme updated to `Catppuccin Mocha`, `force = true` replaces the first-activation template
- **`homes/_modules/shell/fish/default.nix`** — disable `programs.man.generateCaches` on darwin (`programs.man.package` is null at stateVersion >= 26.05, making it a no-op)
- **`hosts/soulwhisper-mba/default.nix`** — `pear-desktop` from nixpkgs instead of the `pear-devs/pear` tap (flaky load-time GitHub request); drop `neteasemusic` cask (vendor HFS+ DMG unmountable via hdiutil on macOS 26.6, installed manually)

## Verification

- `nix eval .#darwinConfigurations.soulwhisper-mba.config.system.build.toplevel.drvPath` evaluates cleanly
- `prek run` all hooks pass (nixfmt applied)