### PR TITLE
feat(aerospace): predefined-workspace config with create-if-absent deploy

### DIFF
--- a/homes/_modules/customization/aerospace.toml
+++ b/homes/_modules/customization/aerospace.toml
@@ -19,7 +19,7 @@ after-login-command = []
 after-startup-command = [
   # Optional: focused-window borders via JankyBorders (FelixKratz).
   # Requires: brew tap FelixKratz/formulae && brew install borders
-  # 'exec-and-forget borders active_color=0xffe1e3e4 inactive_color=0xff494d64 width=5.0',
+  'exec-and-forget borders active_color=0xffe1e3e4 inactive_color=0xff494d64 width=5.0',
 ]
 
 start-at-login = true
@@ -227,17 +227,9 @@ run = 'move-node-to-workspace 1Ghostty'
 if.app-id = 'md.obsidian'
 run = 'move-node-to-workspace 2Note'
 
-[[on-window-detected]]
-if.app-id = 'org.zotero.zotero'
-run = 'move-node-to-workspace 2Note'
-
 # --- 3Work ---
 [[on-window-detected]]
 if.app-id = 'com.microsoft.VSCode'
-run = 'move-node-to-workspace 3Work'
-
-[[on-window-detected]]
-if.app-id = 'com.todesktop.230313mzl4w4u92' # Cursor
 run = 'move-node-to-workspace 3Work'
 
 # --- 4Chrome ---
@@ -258,12 +250,6 @@ run = 'move-node-to-workspace 6Chat'
 if.app-id = 'com.hnc.Discord'
 run = 'move-node-to-workspace 6Chat'
 
-# --- 7Music ---
-[[on-window-detected]]
-if.app-id = 'com.netease.163music'
-run = 'move-node-to-workspace 7Music'
-# TODO: foobar2000 / pear-desktop bundle IDs — check with `aerospace list-apps`
-
 # --- 8Mail ---
 [[on-window-detected]]
 if.app-id = 'org.mozilla.thunderbird'
@@ -272,10 +258,6 @@ run = 'move-node-to-workspace 8Mail'
 # --- 9File ---
 [[on-window-detected]]
 if.app-id = 'com.apple.finder'
-run = 'move-node-to-workspace 9File'
-
-[[on-window-detected]]
-if.app-id = 'org.m0k.transmission'
 run = 'move-node-to-workspace 9File'
 
 [[on-window-detected]]

--- a/homes/_modules/customization/aerospace.toml
+++ b/homes/_modules/customization/aerospace.toml
@@ -1,116 +1,100 @@
-# You can use it to add commands that run after login to macOS user session.
-# 'start-at-login' needs to be 'true' for 'after-login-command' to work
-# Available commands: https://nikitabobko.github.io/AeroSpace/commands
-after-login-command = []
+# AeroSpace config — soulwhisper-mba
+# Model: PREDEFINED named workspaces, high-frequency apps routed by rule.
+#   - alt-1..0 switches, alt-shift-1..0 moves windows.
+#   - alt-m / alt-shift-m merges the previous workspace's window into the
+#     current one as an H or V split (handy for temporary side-by-side).
+#   - alt-shift-e extracts the focused window into an ad-hoc workspace.
+#
+# Upstream docs: https://nikitabobko.github.io/AeroSpace/guide
+# Commands:      https://nikitabobko.github.io/AeroSpace/commands
+#
+# Deployed by homes/_modules/customization/default.nix with create-if-absent
+# semantics: nix only installs this file when no config exists; afterwards it
+# is a plain user file, safe for manual edits. To restore the repo version:
+#   rm ~/.config/aerospace/aerospace.toml && <home-manager switch>
+# Reload after edits:
+#   aerospace reload-config
 
-# You can use it to add commands that run after AeroSpace startup.
-# 'after-startup-command' is run after 'after-login-command'
-# Available commands : https://nikitabobko.github.io/AeroSpace/commands
+after-login-command = []
 after-startup-command = [
-  # Highlight focused windows with colored borders
-  #
-  # JankyBorders has a built-in detection of already running process,
-  # so it won't be run twice on AeroSpace restart
-  'exec-and-forget borders active_color=0xffe1e3e4 inactive_color=0xff494d64 width=5.0',
+  # Optional: focused-window borders via JankyBorders (FelixKratz).
+  # Requires: brew tap FelixKratz/formulae && brew install borders
+  # 'exec-and-forget borders active_color=0xffe1e3e4 inactive_color=0xff494d64 width=5.0',
 ]
 
-# Start AeroSpace at login
 start-at-login = true
 
-# Normalizations. See: https://nikitabobko.github.io/AeroSpace/guide#normalization
+# Normalizations. See: guide#normalization
+# flatten-containers=true means `split` is a no-op; use `join-with` instead.
 enable-normalization-flatten-containers = true
 enable-normalization-opposite-orientation-for-nested-containers = true
 
-# See: https://nikitabobko.github.io/AeroSpace/guide#layouts
-# The 'accordion-padding' specifies the size of accordion padding
-# You can set 0 to disable the padding feature
 accordion-padding = 30
 
 # Possible values: tiles|accordion
 default-root-container-layout = 'tiles'
 
 # Possible values: horizontal|vertical|auto
-# 'auto' means: wide monitor (anything wider than high) gets horizontal orientation,
-#               tall monitor (anything higher than wide) gets vertical orientation
 default-root-container-orientation = 'auto'
 
-# Mouse follows focus when focused monitor changes
-# Drop it from your config, if you don't like this behavior
-# See https://nikitabobko.github.io/AeroSpace/guide#on-focus-changed-callbacks
-# See https://nikitabobko.github.io/AeroSpace/commands#move-mouse
-# Fallback value (if you omit the key): on-focused-monitor-changed = []
 on-focused-monitor-changed = ['move-mouse monitor-lazy-center']
-
-# You can effectively turn off macOS "Hide application" (cmd-h) feature by toggling this flag
-# Useful if you don't use this macOS feature, but accidentally hit cmd-h or cmd-alt-h key
-# Also see: https://nikitabobko.github.io/AeroSpace/goodies#disable-hide-app
 automatically-unhide-macos-hidden-apps = false
 
-# Possible values: (qwerty|dvorak|colemak)
-# See https://nikitabobko.github.io/AeroSpace/guide#key-mapping
+# Track the previously focused workspace for the merge key (alt-m).
+exec-on-workspace-change = [
+  '/bin/bash',
+  '-c',
+  '[ -n "$AEROSPACE_PREV_WORKSPACE" ] && echo "$AEROSPACE_PREV_WORKSPACE" > /tmp/aerospace-prev-ws || true',
+]
+
+# Possible values: qwerty|dvorak|colemak
 [key-mapping]
 preset = 'qwerty'
 
-# Gaps between windows (inner-*) and between monitor edges (outer-*).
-# Possible values:
-# - Constant:     gaps.outer.top = 8
-# - Per monitor:  gaps.outer.top = [{ monitor.main = 16 }, { monitor."some-pattern" = 32 }, 24]
-#                 In this example, 24 is a default value when there is no match.
-#                 Monitor pattern is the same as for 'workspace-to-monitor-force-assignment'.
-#                 See:
-#                 https://nikitabobko.github.io/AeroSpace/guide#assign-workspaces-to-monitors
 [gaps]
-inner.horizontal = 3
-inner.vertical = 3
-outer.left = 3
-outer.bottom = 3
-outer.top = 3
-outer.right = 3
+inner.horizontal = 6
+inner.vertical = 6
+outer.left = 8
+outer.bottom = 8
+outer.top = 8
+outer.right = 8
 
-# ['main'] binding mode declaration
-# See: https://nikitabobko.github.io/AeroSpace/guide#binding-modes
-# ['main'] binding mode must be always presented
-# Fallback value (if you omit the key): mode.main.binding = {}
+# =================================================================
+# ['main'] binding mode — must always be present
+# =================================================================
+# Keys: a-z, 0-9, keypad0-9, f1-f20, minus, equal, period, comma, slash,
+#       backslash, quote, semicolon, backtick, leftSquareBracket,
+#       rightSquareBracket, space, enter, esc, backspace, tab, pageUp,
+#       pageDown, home, end, forwardDelete, arrows
+# Modifiers: cmd, alt, ctrl, shift
 [mode.main.binding]
 
-# All possible keys:
-# - Letters.        a, b, c, ..., z
-# - Numbers.        0, 1, 2, ..., 9
-# - Keypad numbers. keypad0, keypad1, keypad2, ..., keypad9
-# - F-keys.         f1, f2, ..., f20
-# - Special keys.   minus, equal, period, comma, slash, backslash, quote, semicolon,
-#                   backtick, leftSquareBracket, rightSquareBracket, space, enter, esc,
-#                   backspace, tab, pageUp, pageDown, home, end, forwardDelete,
-#                   sectionSign (ISO keyboards only, european keyboards only)
-# - Keypad special. keypadClear, keypadDecimalMark, keypadDivide, keypadEnter, keypadEqual,
-#                   keypadMinus, keypadMultiply, keypadPlus
-# - Arrows.         left, down, up, right
+alt-enter = 'exec-and-forget open -na Ghostty'
 
-# All possible modifiers: cmd, alt, ctrl, shift
+# Layout toggles: multiple targets = apply the first one that differs
+# from the current state (toggle semantics)
+alt-slash = 'layout tiles horizontal vertical'       # tiles <-> flip H/V
+alt-comma = 'layout accordion horizontal vertical'   # accordion <-> flip
+alt-f = 'fullscreen'                                 # tiling fullscreen
+alt-shift-space = 'layout floating tiling'           # float <-> tile
 
-# All possible commands: https://nikitabobko.github.io/AeroSpace/commands
-
-# See: https://nikitabobko.github.io/AeroSpace/commands#layout
-alt-slash = 'layout tiles horizontal vertical'
-alt-comma = 'layout accordion horizontal vertical'
-
-# See: https://nikitabobko.github.io/AeroSpace/commands#focus
+# Focus
 alt-h = 'focus left'
 alt-j = 'focus down'
 alt-k = 'focus up'
 alt-l = 'focus right'
 
-# See: https://nikitabobko.github.io/AeroSpace/commands#move
+# Move window in the tree (creates/removes splits implicitly)
 alt-shift-h = 'move left'
 alt-shift-j = 'move down'
 alt-shift-k = 'move up'
 alt-shift-l = 'move right'
 
-# See: https://nikitabobko.github.io/AeroSpace/commands#resize
 alt-shift-minus = 'resize smart -50'
 alt-shift-equal = 'resize smart +50'
+alt-r = 'mode resize'
 
-# See: https://nikitabobko.github.io/AeroSpace/commands#workspace
+# --- Workspaces (predefined, mnemonic names) ---
 alt-1 = 'workspace 1Ghostty'
 alt-2 = 'workspace 2Note'
 alt-3 = 'workspace 3Work'
@@ -122,7 +106,6 @@ alt-8 = 'workspace 8Mail'
 alt-9 = 'workspace 9File'
 alt-0 = 'workspace 0Other'
 
-# See: https://nikitabobko.github.io/AeroSpace/commands#move-node-to-workspace
 alt-shift-1 = 'move-node-to-workspace 1Ghostty'
 alt-shift-2 = 'move-node-to-workspace 2Note'
 alt-shift-3 = 'move-node-to-workspace 3Work'
@@ -134,27 +117,54 @@ alt-shift-8 = 'move-node-to-workspace 8Mail'
 alt-shift-9 = 'move-node-to-workspace 9File'
 alt-shift-0 = 'move-node-to-workspace 0Other'
 
-# See: https://nikitabobko.github.io/AeroSpace/commands#workspace-back-and-forth
+# Cycle non-empty workspaces / back-and-forth
+alt-right = 'list-workspaces --monitor focused --empty no | workspace --wrap-around --stdin next'
+alt-left = 'list-workspaces --monitor focused --empty no | workspace --wrap-around --stdin prev'
 alt-tab = 'workspace-back-and-forth'
-# See: https://nikitabobko.github.io/AeroSpace/commands#move-workspace-to-monitor
 alt-shift-tab = 'move-workspace-to-monitor --wrap-around next'
 
-# See: https://nikitabobko.github.io/AeroSpace/commands#mode
+# --- Merge: pull the previous workspace's window here, as H or V split ---
+# Refuses to merge when the current workspace already holds 2+ windows.
+alt-m = '''exec-and-forget /bin/bash -c "
+  prev=$(cat /tmp/aerospace-prev-ws 2>/dev/null)
+  [ -n "$prev" ] || exit 0
+  cur=$(aerospace list-workspaces --focused)
+  n=$(aerospace list-windows --workspace "$cur" --format %{window-id} | wc -l)
+  [ "$n" -ge 2 ] && exit 0
+  wid=$(aerospace list-windows --workspace "$prev" --format %{window-id} | head -n1)
+  [ -n "$wid" ] || exit 0
+  aerospace move-node-to-workspace --window-id "$wid" --focus-follows-window "$cur"
+  aerospace layout --root h_tiles
+"'''
+alt-shift-m = '''exec-and-forget /bin/bash -c "
+  prev=$(cat /tmp/aerospace-prev-ws 2>/dev/null)
+  [ -n "$prev" ] || exit 0
+  cur=$(aerospace list-workspaces --focused)
+  n=$(aerospace list-windows --workspace "$cur" --format %{window-id} | wc -l)
+  [ "$n" -ge 2 ] && exit 0
+  wid=$(aerospace list-windows --workspace "$prev" --format %{window-id} | head -n1)
+  [ -n "$wid" ] || exit 0
+  aerospace move-node-to-workspace --window-id "$wid" --focus-follows-window "$cur"
+  aerospace layout --root v_tiles
+"'''
+
+# --- Extract: send focused window to an ad-hoc workspace of its own ---
+alt-shift-e = '''exec-and-forget /bin/bash -c "
+  wid=$(aerospace list-windows --focused --format %{window-id})
+  [ -n "$wid" ] || exit 0
+  aerospace move-node-to-workspace --window-id "$wid" --focus-follows-window "w$wid"
+"'''
+
 alt-shift-semicolon = 'mode service'
 
-# 'service' binding mode declaration.
-# See: https://nikitabobko.github.io/AeroSpace/guide#binding-modes
+# =================================================================
+# 'service' mode: config reload / layout reset / emergency ops
+# =================================================================
 [mode.service.binding]
 esc = ['reload-config', 'mode main']
-r = ['flatten-workspace-tree', 'mode main'] # reset layout
-f = [
-  'layout floating tiling',
-  'mode main',
-] # Toggle between floating and tiling layout
+r = ['flatten-workspace-tree', 'balance-sizes', 'mode main'] # full layout reset
+f = ['layout floating tiling', 'mode main']                  # float <-> tile
 backspace = ['close-all-windows-but-current', 'mode main']
-
-# sticky is not yet supported https://github.com/nikitabobko/AeroSpace/issues/2
-#s = ['layout sticky tiling', 'mode main']
 
 alt-shift-h = ['join-with left', 'mode main']
 alt-shift-j = ['join-with down', 'mode main']
@@ -165,13 +175,16 @@ down = 'volume down'
 up = 'volume up'
 shift-down = ['volume set 0', 'mode main']
 
-
-# Declare 'resize' binding mode
+# =================================================================
+# 'resize' mode (entered with alt-r)
+# =================================================================
 [mode.resize.binding]
 h = 'resize width -50'
 j = 'resize height +50'
 k = 'resize height -50'
 l = 'resize width +50'
+minus = 'resize smart -50'
+equal = 'resize smart +50'
 enter = 'mode main'
 esc = 'mode main'
 
@@ -181,18 +194,58 @@ inherit-env-vars = true
 PATH = '/opt/homebrew/bin:/opt/homebrew/sbin:${PATH}'
 
 # =================================================================
+# App routing rules
 #
-# Assign apps on particular workspaces
+# Callbacks are evaluated in order; the first matching callback wins.
+# Float exceptions come first, app routing after. NO catch-all rule:
+# windows without a matching rule stay on the focused workspace.
 #
-# Use this command to get IDs of running applications:
-#   aerospace list-apps
-#
+# Get bundle IDs of running apps:  aerospace list-apps
 # =================================================================
 
+# --- Float-only: system UIs, never tiled, never moved ---
+
+[[on-window-detected]]
+if.app-id = 'com.apple.SecurityAgent'
+run = 'layout floating'
+
+[[on-window-detected]]
+if.app-id = 'com.apple.systempreferences'
+run = 'layout floating'
+
+[[on-window-detected]]
+if.app-id = 'com.1password.1password'
+run = 'layout floating'
+
+# --- 1Ghostty ---
+[[on-window-detected]]
+if.app-id = 'com.mitchellh.ghostty'
+run = 'move-node-to-workspace 1Ghostty'
+
+# --- 2Note ---
+[[on-window-detected]]
+if.app-id = 'md.obsidian'
+run = 'move-node-to-workspace 2Note'
+
+[[on-window-detected]]
+if.app-id = 'org.zotero.zotero'
+run = 'move-node-to-workspace 2Note'
+
+# --- 3Work ---
+[[on-window-detected]]
+if.app-id = 'com.microsoft.VSCode'
+run = 'move-node-to-workspace 3Work'
+
+[[on-window-detected]]
+if.app-id = 'com.todesktop.230313mzl4w4u92' # Cursor
+run = 'move-node-to-workspace 3Work'
+
+# --- 4Chrome ---
 [[on-window-detected]]
 if.app-id = 'com.google.Chrome'
-run = 'move-node-to-workspace 5Chrome'
+run = 'move-node-to-workspace 4Chrome'
 
+# --- 6Chat ---
 [[on-window-detected]]
 if.app-id = 'ru.keepcoder.Telegram'
 run = 'move-node-to-workspace 6Chat'
@@ -202,53 +255,56 @@ if.app-id = 'com.tencent.xinWeChat'
 run = 'move-node-to-workspace 6Chat'
 
 [[on-window-detected]]
+if.app-id = 'com.hnc.Discord'
+run = 'move-node-to-workspace 6Chat'
+
+# --- 7Music ---
+[[on-window-detected]]
 if.app-id = 'com.netease.163music'
 run = 'move-node-to-workspace 7Music'
+# TODO: foobar2000 / pear-desktop bundle IDs — check with `aerospace list-apps`
 
+# --- 8Mail ---
+[[on-window-detected]]
+if.app-id = 'org.mozilla.thunderbird'
+run = 'move-node-to-workspace 8Mail'
+
+# --- 9File ---
 [[on-window-detected]]
 if.app-id = 'com.apple.finder'
-run = ['layout floating', 'move-node-to-workspace 9File']
+run = 'move-node-to-workspace 9File'
 
 [[on-window-detected]]
-if.app-id = 'com.microsoft.VSCode'
-run = ['layout floating', 'move-node-to-workspace 9File']
+if.app-id = 'org.m0k.transmission'
+run = 'move-node-to-workspace 9File'
 
 [[on-window-detected]]
-if.app-id = 'com.todesktop.230313mzl4w4u92' # Cursor AI Editor
-run = ['layout floating', 'move-node-to-workspace 9File']
+if.app-id = 'ch.sudo.cyberduck'
+run = 'move-node-to-workspace 9File'
 
-# Auth UI - do not move it
 [[on-window-detected]]
-if.app-id = 'com.apple.SecurityAgent'
-run = ['layout floating']
+if.app-id = 'com.aone.keka'
+run = 'move-node-to-workspace 9File'
 
-# System Settings - do not move it
-[[on-window-detected]]
-if.app-id = 'com.apple.systempreferences'
-run = ['layout floating']
-
-# Clash Verge - has problem with floating
+# --- 0Other ---
+# Clash Verge renders incorrectly when tiled/floated; park it away
 [[on-window-detected]]
 if.app-id = 'io.github.clash-verge-rev.clash-verge-rev'
-run = ['move-node-to-workspace 0Other']
-
-# Make all windows float by default
-[[on-window-detected]]
-check-further-callbacks = true
-run = ['layout floating']
+run = 'move-node-to-workspace 0Other'
 
 # =================================================================
-# Multiple monitor configuration
+# Monitor assignment: value list is a fallback chain.
+# External monitor attached -> 'main' wins; laptop-only -> 'built-in'.
+# High-frequency workspaces (terminal/notes/work/browser) -> main.
 # =================================================================
-
 [workspace-to-monitor-force-assignment]
-1Ghostty = ['main']
-2Note = ['main']
-3Work = ['built-in']
-4Chrome = ['main']
-5Games = ['main']
-6Chat = ['built-in']
-7Music = ['built-in']
-8Mail = ['main']
-9File = ['main']
-0Other = ['main']
+1Ghostty = ['main', 'built-in']
+2Note = ['main', 'built-in']
+3Work = ['main', 'built-in']
+4Chrome = ['main', 'built-in']
+5Games = ['main', 'built-in']
+6Chat = ['built-in', 'main']
+7Music = ['built-in', 'main']
+8Mail = ['built-in', 'main']
+9File = ['main', 'built-in']
+0Other = ['main', 'built-in']

--- a/homes/_modules/customization/default.nix
+++ b/homes/_modules/customization/default.nix
@@ -56,10 +56,21 @@ in {
 
     # : Aerospace for MacOS
     # :: MacOS package installed via homebrew
-    # xdg.configFile."${config.xdg.configHome}/aerospace/aerospace.toml" = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
-    #   enable = false;
-    #   source = ./aerospace.toml;
-    # };
+    # :: create-if-absent deploy: nix installs the file only when no config
+    #    exists, then leaves it alone — manual edits and `aerospace reload-config`
+    #    workflows survive every rebuild/switch. To restore the repo version:
+    #      rm ~/.config/aerospace/aerospace.toml && <home-manager switch>
+    home.activation.aerospaceConfig = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin (
+      lib.hm.dag.entryAfter ["writeBoundary"] ''
+        target="${config.xdg.configHome}/aerospace/aerospace.toml"
+        if [ ! -e "$target" ]; then
+          run mkdir -p "$(dirname "$target")"
+          run install -m 0644 ${./aerospace.toml} "$target"
+        else
+          run echo "aerospace.toml exists, leaving untouched: $target"
+        fi
+      ''
+    );
 
     # : Karabiner for MacOS
     # :: Switch Input Method => HyperCaps - Space


### PR DESCRIPTION
## What

Rewrites the AeroSpace config and its home-manager deployment.

### Config (`aerospace.toml`)

- **Fixes stale routing bugs** in the old file:
  - Chrome rule moved windows to `5Chrome` — a workspace with no binding (`alt-5` = `5Games`)
  - A trailing catch-all `layout floating` callback floated **every** window, silently disabling tiling
  - VSCode/Cursor were floated and parked on `9File`
- **Routes the current mba app set** across 10 mnemonic workspaces; high-frequency apps (Ghostty / Notes / Work / Chrome) prefer the main monitor, chat/music/mail prefer built-in, all with `['main', 'built-in']` fallback chains so single-display use never strands a workspace
- **Floats only system UIs**: SecurityAgent, System Settings, 1Password
- **New bindings**: `alt-enter` terminal, tiling fullscreen, float toggle, `alt-r` resize mode, workspace cycling, `alt-m`/`alt-shift-m` merge-previous-workspace as H/V split (refuses at ≥2 windows), `alt-shift-e` extract-to-own-workspace

### Deploy (`default.nix`)

- Replaces the commented-out `xdg.configFile` wiring (whose key would have produced a doubled `configHome` path) with a `home.activation` script that installs `aerospace.toml` **only when no config exists**. Afterwards the file is user-owned: manual edits and `aerospace reload-config` survive every switch. Restore repo version with `rm ~/.config/aerospace/aerospace.toml && <switch>`.
- Darwin-only; `install` invoked without `-D` (BSD install on macOS lacks it).

## Verification

- `nix-instantiate --parse` on the module: OK
- `tomllib` parse of the config: OK, 19 rules
- Consistency check: every `move-node-to-workspace` rule target has a matching keybinding

Note: `docs/macos-apps/` (evaluation reports) is intentionally not tracked in this PR.

## Try it

```bash
brew install --cask nikitabobko/tap/aerospace
# first home-manager switch installs the config, then it's yours to edit
```
