### PR TITLE
fix(homes): wrap aerospace activation in mkMerge list element

### DIFF
--- a/.github/workflows/nix-build.yaml
+++ b/.github/workflows/nix-build.yaml
@@ -80,9 +80,14 @@ jobs:
       - name: Build previous ${{ matrix.system }} system
         run: |
           # New hosts have no previous build on main; skip instead of failing.
-          if ! ${{ runner.os == 'macOS' && 'sudo ' || '' }}$(which nix) eval \
-            "github:soulwhisper/nix-config#ciSystems" --apply builtins.attrNames --json \
-            | grep -q '"${{ matrix.system }}"'; then
+          # Main itself may also fail to evaluate (e.g. when this PR is the fix
+          # for a breakage on main); skip as well so the new build still runs.
+          if ! prev_attrs=$(${{ runner.os == 'macOS' && 'sudo ' || '' }}$(which nix) eval \
+            "github:soulwhisper/nix-config#ciSystems" --apply builtins.attrNames --json 2>/dev/null); then
+            echo "::notice::main does not evaluate; skipping previous build"
+            exit 0
+          fi
+          if ! grep -q '"${{ matrix.system }}"' <<<"$prev_attrs"; then
             echo "::notice::no previous ${{ matrix.system }} system on main; skipping"
             exit 0
           fi

--- a/.github/workflows/nix-build.yaml
+++ b/.github/workflows/nix-build.yaml
@@ -91,13 +91,18 @@ jobs:
             echo "::notice::no previous ${{ matrix.system }} system on main; skipping"
             exit 0
           fi
-          ${{ runner.os == 'macOS' && 'sudo ' || '' }}$(which nix) build \
+          # A broken main (e.g. the one this PR fixes) must not block the new
+          # build below; skip the previous build and the diff instead.
+          if ! ${{ runner.os == 'macOS' && 'sudo ' || '' }}$(which nix) build \
             "github:soulwhisper/nix-config#ciSystems.${{ matrix.system }}" \
             --profile ./profile \
             --no-write-lock-file \
             --show-trace \
             --log-format raw \
-             > >(tee stdout.log) 2> >(tee /tmp/nix-build-err.log >&2)
+             > >(tee stdout.log) 2> >(tee /tmp/nix-build-err.log >&2); then
+            echo "::notice::previous ${{ matrix.system }} build failed; skipping diff baseline"
+            exit 0
+          fi
 
       - name: Build new ${{ matrix.system }} system
         run: |

--- a/homes/_modules/customization/default.nix
+++ b/homes/_modules/customization/default.nix
@@ -71,8 +71,8 @@ in
     #    exists, then leaves it alone — manual edits and `aerospace reload-config`
     #    workflows survive every rebuild/switch. To restore the repo version:
     #      rm ~/.config/aerospace/aerospace.toml && <home-manager switch>
-    home.activation.aerospaceConfig = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin (
-      lib.hm.dag.entryAfter ["writeBoundary"] ''
+    (lib.mkIf isDarwin {
+      home.activation.aerospaceConfig = lib.hm.dag.entryAfter ["writeBoundary"] ''
         target="${config.xdg.configHome}/aerospace/aerospace.toml"
         if [ ! -e "$target" ]; then
           run mkdir -p "$(dirname "$target")"
@@ -80,8 +80,8 @@ in
         else
           run echo "aerospace.toml exists, leaving untouched: $target"
         fi
-      ''
-    );
+      '';
+    })
 
     # : Karabiner for MacOS
     # :: Switch Input Method => HyperCaps - Space


### PR DESCRIPTION
## Problem

PR #948 (`feat/aerospace-config`) added `home.activation.aerospaceConfig` as a plain attribute-set entry. Meanwhile main had restructured `homes/_modules/customization/default.nix` to `config = lib.mkMerge [ (lib.mkIf isDarwin { ... }) ... ]`. The textual merge was clean but semantically broken: a bare attrset entry landed inside the list, producing:

```
error: syntax error, unexpected '='
at homes/_modules/customization/default.nix:74:37:
   74|     home.activation.aerospaceConfig = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin (
```

The failure escaped the merge because the push-to-main workflow skips runs whose head commit message starts with `Merge pull request` (nix-build.yaml). It then broke every subsequent CI run: the `Build previous system` step evals `github:soulwhisper/nix-config#ciSystems` (main), which no longer evaluates.

## Fix

1. **`homes/_modules/customization/default.nix`** — wrap the aerospace activation in `(lib.mkIf isDarwin { ... })`, matching the surrounding mkMerge list elements.
2. **`.github/workflows/nix-build.yaml`** — the previous-build step now also skips (with a notice) when main fails to evaluate, mirroring the existing new-host skip. A broken main can no longer block the PR that fixes it; the new-build step still validates the change.

## Verification

- `nix-instantiate --parse` on the fixed module: OK
- `nix eval .#ciSystems.nix-ops.drvPath` and `.#ciSystems.nix-dev.drvPath` (full module evaluation incl. home-manager): OK
- `nix build .#ciSystems.nix-ops`: OK locally (x86_64-linux)
- Darwin drvPath eval on x86_64-linux fails on catppuccin-starship IFD platform mismatch (aarch64-darwin) — pre-existing, unrelated; CI builds those on macos-latest runners.